### PR TITLE
Allow to hide migration stdout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcc-code/arango-migrate",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Migrate arango databases",
   "main": "lib/src/",
   "types": "lib/src/",

--- a/src/setup-tests.ts
+++ b/src/setup-tests.ts
@@ -41,7 +41,7 @@ type foxx = {
 // to finishnpm
 const execPromise = promisify(exec);
 
-const importDB = async (config: ArangoDBConfig,deleteDatabaseFirst = false,updateFoxxServiceToDB:boolean = true): Promise<void> => {
+const importDB = async (config: ArangoDBConfig,deleteDatabaseFirst = false,updateFoxxServiceToDB:boolean = true, silent:boolean = true): Promise<void> => {
 
   if(deleteDatabaseFirst){
     await deleteDatabase(config)
@@ -52,7 +52,12 @@ const importDB = async (config: ArangoDBConfig,deleteDatabaseFirst = false,updat
   let location = process.cwd();
   config.scriptsFolderPath = config.scriptsFolderPath === undefined ? "/node_modules/@bcc-code/arango-migrate/src/util_scripts" : config.scriptsFolderPath
   let bat =  require.resolve(`${location}${config.scriptsFolderPath}/import-test-db.${scriptExtension}`);
-   bat = `${bat} ${config.url} ${config.auth.username} ${config.databaseName} ${config.auth.password} "${config.testDataPath}"`
+  if(scriptExtension === 'sh'){
+    bat = `${bat} ${config.url} ${config.auth.username} ${config.databaseName} ${config.auth.password} "${config.testDataPath}" "${silent}"`
+  } else {
+    bat = `${bat} ${config.url} ${config.auth.username} ${config.databaseName} ${config.auth.password} "${config.testDataPath}"`
+  }
+   
   // Execute the bat script
   try {
     let stdout = await execPromise(bat)

--- a/src/util_scripts/import-test-db.sh
+++ b/src/util_scripts/import-test-db.sh
@@ -20,11 +20,12 @@ DATABASE="$3"
 PASSWORD="$4"
 RELATIVE_PATH_TO_TEST_DATA_WINDOWS_FORMAT="$5"
 RELATIVE_PATH_TO_TEST_DATA_LINUX_FORMAT=$(printf "%s" "$RELATIVE_PATH_TO_TEST_DATA_WINDOWS_FORMAT" | sed 's/\\/\//g')
+SILENT_OUTPUT="$6"
 
 FULL_PATH_TO_TEST_DATA="$(pwd)/$RELATIVE_PATH_TO_TEST_DATA_LINUX_FORMAT"
 echo Full path to test data: $FULL_PATH_TO_TEST_DATA
 
-if [ -n "$6" & "$6" == "true"]; then
+if [ -n "$SILENT_OUTPUT" & "$SILENT_OUTPUT" == "true"]; then
   arangorestore \
   --server.database "$DATABASE" \
   --server.username "$USERNAME" \

--- a/src/util_scripts/import-test-db.sh
+++ b/src/util_scripts/import-test-db.sh
@@ -24,7 +24,8 @@ RELATIVE_PATH_TO_TEST_DATA_LINUX_FORMAT=$(printf "%s" "$RELATIVE_PATH_TO_TEST_DA
 FULL_PATH_TO_TEST_DATA="$(pwd)/$RELATIVE_PATH_TO_TEST_DATA_LINUX_FORMAT"
 echo Full path to test data: $FULL_PATH_TO_TEST_DATA
 
-arangorestore \
+if [ -n "$6" & "$6" == "true"]; then
+  arangorestore \
   --server.database "$DATABASE" \
   --server.username "$USERNAME" \
   --server.password "$PASSWORD" \
@@ -33,3 +34,15 @@ arangorestore \
   --input-directory "$FULL_PATH_TO_TEST_DATA" \
   --create-database true \
   --include-system-collections true \
+  > /dev/null
+else
+  arangorestore \
+  --server.database "$DATABASE" \
+  --server.username "$USERNAME" \
+  --server.password "$PASSWORD" \
+  --server.authentication false \
+  --server.endpoint "$URL" \
+  --input-directory "$FULL_PATH_TO_TEST_DATA" \
+  --create-database true \
+  --include-system-collections true
+fi


### PR DESCRIPTION
This PR allows (and turns on by default) to swallow arangorestore std console output. WORKS ONLY FOR LINUX.